### PR TITLE
Introduce JPA relationships

### DIFF
--- a/src/main/java/comflower/sagongsa/comment/Comment.java
+++ b/src/main/java/comflower/sagongsa/comment/Comment.java
@@ -37,7 +37,7 @@ public class Comment {
     private Long editedAt;
 
     @ManyToOne
-    @JoinColumn(name = "parent_id", insertable = false, updatable = false)
+    @JoinColumn(name = "parent_id")
     private Comment parent;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/comflower/sagongsa/comment/Comment.java
+++ b/src/main/java/comflower/sagongsa/comment/Comment.java
@@ -21,7 +21,7 @@ public class Comment {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "post_id", insertable = false, updatable = false, nullable = false)
+    @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     @ManyToOne

--- a/src/main/java/comflower/sagongsa/comment/Comment.java
+++ b/src/main/java/comflower/sagongsa/comment/Comment.java
@@ -25,7 +25,7 @@ public class Comment {
     private Post post;
 
     @ManyToOne
-    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
     @Column(nullable = false)

--- a/src/main/java/comflower/sagongsa/comment/Comment.java
+++ b/src/main/java/comflower/sagongsa/comment/Comment.java
@@ -1,7 +1,12 @@
 package comflower.sagongsa.comment;
 
+import comflower.sagongsa.post.Post;
+import comflower.sagongsa.user.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,11 +20,13 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne
+    @JoinColumn(name = "post_id", insertable = false, updatable = false, nullable = false)
+    private Post post;
 
-    @Column(nullable = false)
-    private Long authorId;
+    @ManyToOne
+    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    private User author;
 
     @Column(nullable = false)
     private String content;
@@ -29,5 +36,10 @@ public class Comment {
 
     private Long editedAt;
 
-    private Long parentId;
+    @ManyToOne
+    @JoinColumn(name = "parent_id", insertable = false, updatable = false)
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> replies = new ArrayList<>();
 }

--- a/src/main/java/comflower/sagongsa/comment/CommentController.java
+++ b/src/main/java/comflower/sagongsa/comment/CommentController.java
@@ -3,6 +3,7 @@ package comflower.sagongsa.comment;
 import comflower.sagongsa.comment.request.CreateCommentRequest;
 import comflower.sagongsa.comment.request.EditCommentRequest;
 import comflower.sagongsa.comment.response.UserCommentResponse;
+import comflower.sagongsa.comment.response.CommentResponse;
 import comflower.sagongsa.common.exception.InvalidFormBodyException;
 import comflower.sagongsa.common.request.RequestValidator;
 import comflower.sagongsa.user.User;
@@ -34,13 +35,13 @@ public class CommentController {
     public List<UserCommentResponse> getCommentsByPostId(@PathVariable Long postId) {
         var comments = commentService.getCommentsByPost(postId);
         return comments.stream()
-                .map(c -> new UserCommentResponse(c.getComment(), new UserResponse(c.getAuthor())))
+                .map(c -> new UserCommentResponse(new CommentResponse(c.getComment()), new UserResponse(c.getAuthor())))
                 .toList();
     }
 
     @PostMapping("/posts/{postId}/comments")
     @SecurityRequirement(name = "bearerAuth")
-    public Comment createComment(
+    public CommentResponse createComment(
             @AuthenticationPrincipal User user,
             @PathVariable Long postId,
             @Validated @RequestBody CreateCommentRequest request, BindingResult bindingResult
@@ -49,12 +50,12 @@ public class CommentController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return commentService.createComment(user.getId(), postId, request);
+        return new CommentResponse(commentService.createComment(user.getId(), postId, request));
     }
 
     @PutMapping("/posts/{postId}/comments/{commentId}")
     @SecurityRequirement(name = "bearerAuth")
-    public Comment editComment(
+    public CommentResponse editComment(
             @PathVariable Long postId, @PathVariable Long commentId,
             @Validated @RequestBody EditCommentRequest request, BindingResult bindingResult
     ) {
@@ -62,7 +63,7 @@ public class CommentController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return commentService.editComment(postId, commentId, request);
+        return new CommentResponse(commentService.editComment(postId, commentId, request));
     }
 
     @DeleteMapping("/posts/{postId}/comments/{commentId}")

--- a/src/main/java/comflower/sagongsa/comment/CommentRepository.java
+++ b/src/main/java/comflower/sagongsa/comment/CommentRepository.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT c as comment, u as author " +
-            "FROM comment c LEFT JOIN user u ON c.authorId = u.id WHERE c.postId = :postId")
+    @Query("SELECT c as comment, c.author as author FROM Comment c WHERE c.post.id = :postId")
     List<UserCommentProjection> findByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/comflower/sagongsa/comment/CommentService.java
+++ b/src/main/java/comflower/sagongsa/comment/CommentService.java
@@ -42,7 +42,7 @@ public class CommentService {
                 .author(User.builder().id(authorId).build())
                 .content(request.getContent())
                 .createdAt(System.currentTimeMillis())
-                .parent(Comment.builder().id(request.getParentId()).build())
+                .parent(parentId != null ? Comment.builder().id(parentId).build() : null)
                 .build();
         return commentRepository.save(comment);
     }

--- a/src/main/java/comflower/sagongsa/comment/CommentService.java
+++ b/src/main/java/comflower/sagongsa/comment/CommentService.java
@@ -3,9 +3,11 @@ package comflower.sagongsa.comment;
 import comflower.sagongsa.common.exception.UnknownCommentException;
 import comflower.sagongsa.common.exception.UnknownPostException;
 import comflower.sagongsa.comment.projection.UserCommentProjection;
+import comflower.sagongsa.post.Post;
 import comflower.sagongsa.post.PostRepository;
 import comflower.sagongsa.comment.request.CreateCommentRequest;
 import comflower.sagongsa.comment.request.EditCommentRequest;
+import comflower.sagongsa.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +38,11 @@ public class CommentService {
         }
 
         Comment comment = Comment.builder()
-                .postId(postId)
-                .authorId(authorId)
+                .post(Post.builder().id(postId).build())
+                .author(User.builder().id(authorId).build())
                 .content(request.getContent())
                 .createdAt(System.currentTimeMillis())
-                .parentId(request.getParentId())
+                .parent(Comment.builder().id(request.getParentId()).build())
                 .build();
         return commentRepository.save(comment);
     }

--- a/src/main/java/comflower/sagongsa/comment/response/CommentResponse.java
+++ b/src/main/java/comflower/sagongsa/comment/response/CommentResponse.java
@@ -1,0 +1,29 @@
+package comflower.sagongsa.comment.response;
+
+import comflower.sagongsa.comment.Comment;
+import lombok.Getter;
+
+@Getter
+public class CommentResponse {
+    private final long id;
+    private final long postId;
+    private final long authorId;
+    private final String content;
+    private final long createdAt;
+    private final Long editedAt;
+    private final Long parentId;
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.postId = comment.getPost().getId();
+        this.authorId = comment.getAuthor().getId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+        this.editedAt = comment.getEditedAt();
+        if (comment.getParent() == null) {
+            this.parentId = null;
+        } else {
+            this.parentId = comment.getParent().getId();
+        }
+    }
+} 

--- a/src/main/java/comflower/sagongsa/comment/response/UserCommentResponse.java
+++ b/src/main/java/comflower/sagongsa/comment/response/UserCommentResponse.java
@@ -1,8 +1,7 @@
 package comflower.sagongsa.comment.response;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import comflower.sagongsa.comment.Comment;
 import comflower.sagongsa.user.response.UserResponse;
 
-public record UserCommentResponse(@JsonUnwrapped Comment comment, UserResponse author) {
+public record UserCommentResponse(@JsonUnwrapped CommentResponse comment, UserResponse author) {
 }

--- a/src/main/java/comflower/sagongsa/contest/Contest.java
+++ b/src/main/java/comflower/sagongsa/contest/Contest.java
@@ -1,5 +1,6 @@
 package comflower.sagongsa.contest;
 
+import comflower.sagongsa.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,8 +16,9 @@ public class Contest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long authorId;
+    @ManyToOne
+    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    private User author;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/comflower/sagongsa/contest/Contest.java
+++ b/src/main/java/comflower/sagongsa/contest/Contest.java
@@ -17,7 +17,7 @@ public class Contest {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
     @Column(nullable = false)

--- a/src/main/java/comflower/sagongsa/contest/ContestController.java
+++ b/src/main/java/comflower/sagongsa/contest/ContestController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import comflower.sagongsa.contest.response.ContestResponse;
+
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "contest")
@@ -30,13 +32,15 @@ public class ContestController {
     }
 
     @GetMapping("/contests")
-    public List<Contest> getContests() {
-        return contestService.getAllContests();
+    public List<ContestResponse> getContests() {
+        return contestService.getAllContests().stream()
+                .map(ContestResponse::new)
+                .toList();
     }
 
     @PostMapping("/contests")
     @SecurityRequirement(name = "bearerAuth")
-    public Contest createContest(
+    public ContestResponse createContest(
             @AuthenticationPrincipal User user,
             @Validated @RequestBody CreateContestRequest request, BindingResult bindingResult
     ) {
@@ -44,17 +48,17 @@ public class ContestController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return contestService.createContest(user.getId(), request);
+        return new ContestResponse(contestService.createContest(user.getId(), request));
     }
 
     @GetMapping("/contests/{contestId}")
-    public Contest getContest(@PathVariable Long contestId) {
-        return contestService.getContest(contestId);
+    public ContestResponse getContest(@PathVariable Long contestId) {
+        return new ContestResponse(contestService.getContest(contestId));
     }
 
     @PutMapping("/contests/{contestId}")
     @SecurityRequirement(name = "bearerAuth")
-    public Contest editContest(
+    public ContestResponse editContest(
             @PathVariable Long contestId,
             @Validated @RequestBody EditContestRequest request, BindingResult bindingResult
     ) {
@@ -62,7 +66,7 @@ public class ContestController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return contestService.editContest(contestId, request);
+        return new ContestResponse(contestService.editContest(contestId, request));
     }
 
     @DeleteMapping("/contests/{contestId}")

--- a/src/main/java/comflower/sagongsa/contest/ContestService.java
+++ b/src/main/java/comflower/sagongsa/contest/ContestService.java
@@ -3,6 +3,7 @@ package comflower.sagongsa.contest;
 import comflower.sagongsa.contest.request.CreateContestRequest;
 import comflower.sagongsa.contest.request.EditContestRequest;
 import comflower.sagongsa.common.exception.UnknownContestException;
+import comflower.sagongsa.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,7 @@ public class ContestService {
 
     public Contest createContest(Long userId, CreateContestRequest request) {
         Contest contest = Contest.builder()
-                .authorId(userId)
+                .author(User.builder().id(userId).build())
                 .title(request.getTitle())
                 .thumbnail(request.getThumbnail())
                 .prize(request.getPrize())

--- a/src/main/java/comflower/sagongsa/contest/response/ContestResponse.java
+++ b/src/main/java/comflower/sagongsa/contest/response/ContestResponse.java
@@ -1,0 +1,29 @@
+package comflower.sagongsa.contest.response;
+
+import comflower.sagongsa.contest.Contest;
+import lombok.Getter;
+
+@Getter
+public class ContestResponse {
+    private final long id;
+    private final long authorId;
+    private final String title;
+    private final String thumbnail;
+    private final String prize;
+    private final long startedAt;
+    private final long endedAt;
+    private final String link;
+    private final int topic;
+
+    public ContestResponse(Contest contest) {
+        this.id = contest.getId();
+        this.authorId = contest.getAuthor().getId();
+        this.title = contest.getTitle();
+        this.thumbnail = contest.getThumbnail();
+        this.prize = contest.getPrize();
+        this.startedAt = contest.getStartedAt();
+        this.endedAt = contest.getEndedAt();
+        this.link = contest.getLink();
+        this.topic = contest.getTopic();
+    }
+} 

--- a/src/main/java/comflower/sagongsa/post/Post.java
+++ b/src/main/java/comflower/sagongsa/post/Post.java
@@ -21,7 +21,7 @@ public class Post {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
     @Column(nullable = false)

--- a/src/main/java/comflower/sagongsa/post/Post.java
+++ b/src/main/java/comflower/sagongsa/post/Post.java
@@ -1,7 +1,12 @@
 package comflower.sagongsa.post;
 
+import comflower.sagongsa.comment.Comment;
+import comflower.sagongsa.user.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,8 +20,9 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long authorId;
+    @ManyToOne
+    @JoinColumn(name = "author_id", insertable = false, updatable = false, nullable = false)
+    private User author;
 
     @Column(nullable = false)
     private String title;
@@ -38,4 +44,7 @@ public class Post {
 
     @Column(nullable = false)
     private long endedAt;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/comflower/sagongsa/post/PostController.java
+++ b/src/main/java/comflower/sagongsa/post/PostController.java
@@ -4,6 +4,7 @@ import comflower.sagongsa.common.exception.InvalidFormBodyException;
 import comflower.sagongsa.post.request.CreatePostRequest;
 import comflower.sagongsa.post.request.EditPostRequest;
 import comflower.sagongsa.common.request.RequestValidator;
+import comflower.sagongsa.post.response.PostResponse;
 import comflower.sagongsa.user.User;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,18 +31,20 @@ public class PostController {
     }
 
     @GetMapping("/posts")
-    public List<Post> getPosts() {
-        return postService.getPosts();
+    public List<PostResponse> getPosts() {
+        return postService.getPosts().stream()
+                .map(PostResponse::new)
+                .toList();
     }
 
     @GetMapping("/posts/{postId}")
-    public Post getPost(@PathVariable Long postId) {
-        return postService.getPost(postId);
+    public PostResponse getPost(@PathVariable Long postId) {
+        return new PostResponse(postService.getPost(postId));
     }
 
     @PostMapping("/posts")
     @SecurityRequirement(name = "bearerAuth")
-    public Post createPost(
+    public PostResponse createPost(
             @AuthenticationPrincipal User user,
             @Validated @RequestBody CreatePostRequest request, BindingResult bindingResult
     ) {
@@ -49,12 +52,12 @@ public class PostController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return postService.createPost(user.getId(), request);
+        return new PostResponse(postService.createPost(user.getId(), request));
     }
 
     @PutMapping("/posts/{postId}")
     @SecurityRequirement(name = "bearerAuth")
-    public Post editPost(
+    public PostResponse editPost(
             @PathVariable Long postId,
             @AuthenticationPrincipal User user,
             @Validated @RequestBody EditPostRequest request, BindingResult bindingResult
@@ -63,7 +66,7 @@ public class PostController {
             throw new InvalidFormBodyException(bindingResult);
         }
 
-        return postService.editPost(postId, user, request);
+        return new PostResponse(postService.editPost(postId, user, request));
     }
 
     @DeleteMapping("/posts/{postId}")

--- a/src/main/java/comflower/sagongsa/post/PostService.java
+++ b/src/main/java/comflower/sagongsa/post/PostService.java
@@ -27,7 +27,7 @@ public class PostService {
 
     public Post createPost(Long authorId, CreatePostRequest request) {
         Post post = Post.builder()
-                .authorId(authorId)
+                .author(User.builder().id(authorId).build())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .memberCount(request.getMemberCount())
@@ -43,7 +43,7 @@ public class PostService {
     public Post editPost(Long postId, User user, EditPostRequest request) {
         Post post = getPost(postId);
 
-        if (!Objects.equals(post.getAuthorId(), user.getId())) {
+        if (!Objects.equals(post.getAuthor().getId(), user.getId())) {
             throw new UnauthorizedException();
         }
 

--- a/src/main/java/comflower/sagongsa/post/response/PostResponse.java
+++ b/src/main/java/comflower/sagongsa/post/response/PostResponse.java
@@ -1,0 +1,29 @@
+package comflower.sagongsa.post.response;
+
+import comflower.sagongsa.post.Post;
+import lombok.Getter;
+
+@Getter
+public class PostResponse {
+    private final long id;
+    private final long authorId;
+    private final String title;
+    private final String content;
+    private final int memberCount;
+    private final int maxMemberCount;
+    private final int topic;
+    private final long createdAt;
+    private final long endedAt;
+
+    public PostResponse(Post post) {
+        this.id = post.getId();
+        this.authorId = post.getAuthor().getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.memberCount = post.getMemberCount();
+        this.maxMemberCount = post.getMaxMemberCount();
+        this.topic = post.getTopic();
+        this.createdAt = post.getCreatedAt();
+        this.endedAt = post.getEndedAt();
+    }
+}

--- a/src/main/java/comflower/sagongsa/user/User.java
+++ b/src/main/java/comflower/sagongsa/user/User.java
@@ -1,8 +1,13 @@
 package comflower.sagongsa.user;
 
+import comflower.sagongsa.comment.Comment;
+import comflower.sagongsa.contest.Contest;
+import comflower.sagongsa.post.Post;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,4 +49,13 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private Avatar avatar;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private List<Post> posts;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private List<Contest> contests;
 }


### PR DESCRIPTION
This PR also fixes an issue where the `@Query` annotation used a native query without explicitly setting `nativeQuery = true`, hence causing an error where the entity could not be resolved by table name.

Fixes SAG-23